### PR TITLE
add item background color support

### DIFF
--- a/lib/src/navigation_bar.dart
+++ b/lib/src/navigation_bar.dart
@@ -128,7 +128,7 @@ class _TitledBottomNavigationBarState extends State<TitledBottomNavigationBar>
 
   Widget _buildItemWidget(TitledNavigationBarItem item, bool isSelected) {
     return Container(
-      color: Colors.white,
+      color: item.backgroundColor,
       height: BAR_HEIGHT,
       width: width / items.length,
       child: Stack(

--- a/lib/src/navigation_bar_item.dart
+++ b/lib/src/navigation_bar_item.dart
@@ -3,9 +3,11 @@ import 'package:flutter/material.dart';
 class TitledNavigationBarItem {
   final String title;
   final IconData icon;
+  final Color backgroundColor;
 
   TitledNavigationBarItem({
     @required this.icon,
     @required this.title,
+    this.backgroundColor = Colors.white,
   });
 }


### PR DESCRIPTION
Add item background color support.
So I can make a bar like after
![bottom_bar](https://user-images.githubusercontent.com/5875432/55202797-df862200-5203-11e9-9104-f832b83da312.jpg)
