### PR TITLE
Update navigation_bar.dart

### DIFF
--- a/lib/src/navigation_bar.dart
+++ b/lib/src/navigation_bar.dart
@@ -154,7 +154,7 @@ class _TitledBottomNavigationBarState extends State<TitledBottomNavigationBar>
           ),
           AnimatedAlign(
             duration: duration,
-            alignment: isSelected ? Alignment.center : Alignment(0, 2.6),
+            alignment: isSelected ? Alignment.center : Alignment(0, 5.2),
             child: reverse ? _buildText(item) : _buildIcon(item),
           ),
         ],


### PR DESCRIPTION
Move a little bit down. This will fully hide the Icon/Text in iPhone XR when the nav Item is not selected. Without this change, Text and Icon are showing together in iPhone X/R.