### PR TITLE
Fix setState error caused by init

### DIFF
--- a/lib/src/navigation_bar.dart
+++ b/lib/src/navigation_bar.dart
@@ -51,13 +51,6 @@ class _TitledBottomNavigationBarState extends State<TitledBottomNavigationBar>
   Color activeColor;
   Duration duration = Duration(milliseconds: 270);
 
-  @override
-  void initState() {
-    _select(widget.currentIndex);
-
-    super.initState();
-  }
-
   double _getIndicatorPosition(int index) {
     return (-1 + (2 / (items.length - 1) * index));
   }


### PR DESCRIPTION
setState within onTap is unable to build preventing easy navigation. 

Below code will not build with current init
Without setState within onTap, body will not navigate to the selected index. 

```Dart
@override
  Widget build(BuildContext context) {
    final screens = [MyHomePage(), Money(), Account()];
    return Scaffold(
      primary: false,
      bottomNavigationBar: TitledBottomNavigationBar(
        currentIndex: currentIndex,
        onTap: (val) {
          if (mounted) {
            setState(() {
              currentIndex = val;
            });
          }
        },
        items: [
          TitledNavigationBarItem(icon: Entypo.wallet, title: 'Home'),
          TitledNavigationBarItem(icon: FontAwesome.dollar, title: 'Manage'),
          TitledNavigationBarItem(icon: Icons.account_circle, title: 'User'),
        ],
      ),
      body: screens[currentIndex],
    );
  }
}
```

TitledBottomNavigationBar can still function as before without setState. This simply makes navigating pages easier. 